### PR TITLE
Fixed selling bug

### DIFF
--- a/Assets/Prefabs/Towers/AxeTurret/AxeTurretHolo.prefab
+++ b/Assets/Prefabs/Towers/AxeTurret/AxeTurretHolo.prefab
@@ -239,7 +239,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0c4fd1a3795e38f42b486c9bd6a8fc00, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  canInteract: 1
   tower: {fileID: 8637078598552028507, guid: 2229dc52bdd1e6c4384f2d306dcd4df5, type: 3}
+  _towerScriptableObject: {fileID: 11400000, guid: a59d08db63548fb4b851e0848fc561ec, type: 2}
 --- !u!1 &3049860759657918080
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Towers/AxeTurret/AxeTurretHolo.prefab
+++ b/Assets/Prefabs/Towers/AxeTurret/AxeTurretHolo.prefab
@@ -239,9 +239,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0c4fd1a3795e38f42b486c9bd6a8fc00, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  canInteract: 1
   tower: {fileID: 8637078598552028507, guid: 2229dc52bdd1e6c4384f2d306dcd4df5, type: 3}
-  _towerScriptableObject: {fileID: 11400000, guid: a59d08db63548fb4b851e0848fc561ec, type: 2}
 --- !u!1 &3049860759657918080
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Towers/LightningTurret/LightningTurretHolo.prefab
+++ b/Assets/Prefabs/Towers/LightningTurret/LightningTurretHolo.prefab
@@ -475,7 +475,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   canInteract: 1
   tower: {fileID: 7425059109847644991, guid: 465be707821a3d14cbc434b02dc72bdb, type: 3}
-  _towerScriptableObject: {fileID: 11400000, guid: 2ec78001a1c2b2d4bbf643cf65b22984, type: 2}
 --- !u!1 &8081150325412496220
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Towers/LightningTurret/LightningTurretHolo.prefab
+++ b/Assets/Prefabs/Towers/LightningTurret/LightningTurretHolo.prefab
@@ -475,6 +475,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   canInteract: 1
   tower: {fileID: 7425059109847644991, guid: 465be707821a3d14cbc434b02dc72bdb, type: 3}
+  _towerScriptableObject: {fileID: 11400000, guid: 2ec78001a1c2b2d4bbf643cf65b22984, type: 2}
 --- !u!1 &8081150325412496220
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Towers/WheelTurret/WheelTurretHolo.prefab
+++ b/Assets/Prefabs/Towers/WheelTurret/WheelTurretHolo.prefab
@@ -272,6 +272,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   canInteract: 1
   tower: {fileID: 2983117196373584133, guid: a86ee555d85992147a70625145af137b, type: 3}
+  _towerScriptableObject: {fileID: 11400000, guid: 2c0affb1e8eaf774a9e76ec9e5098216, type: 2}
 --- !u!1 &4780342758878589116
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/PlayerStateController.cs
+++ b/Assets/Scripts/Player/PlayerStateController.cs
@@ -30,26 +30,38 @@ public partial class PlayerStateController : MonoBehaviour
     private InventoryManager inventoryManager;
 
     private HashSet<Interactable> interactables = new HashSet<Interactable>(); // List of interactables in range
+
     [ReadOnly, SerializeField]
     private Interactable heldInteractable;
+
     [ReadOnly, SerializeField]
     private Interactable focusedInteractable; // The currently focused interactable
+
     [ReadOnly, SerializeField]
     private GameObject liftedObject; // Object being lifted
+
     public Transform inventory; // Where items are carried
+
     private HexGrid terrain; // Reference to the terrain
+
     [ReadOnly, SerializeField]
     private HexCell targetCell;
+
     [SerializeField]
     private Animator anim; //Reference to animation controller of the player
+
     [SerializeField]
     private Transform heldItemBone;
+
     public PlayerStates CurrentState { get => _currentState; private set => _currentState = value; }
+
     public delegate void PlayerStateDelegate(PlayerStates newState, PlayerStates oldState);
+
     public PlayerStateDelegate onPlayerStateChange; //To allow other components to subscribe to stateChange events
+
     private static readonly int liftingAnimatorParam = Animator.StringToHash("Lifting");
     private static readonly int planningAnimatorParam = Animator.StringToHash("Planning");
-   
+
     void Awake()
     {
         motion = GetComponent<PlayerMotion>();
@@ -66,7 +78,7 @@ public partial class PlayerStateController : MonoBehaviour
 
         OnDestroy_Input();
     }
-    
+
     private void Die(DamageInfo dmg)
     {
         // Drop anything we are carrying
@@ -323,7 +335,7 @@ public partial class PlayerStateController : MonoBehaviour
         if (!(heldInteractable is TurretPrefabConstruction tower))
             return;
 
-        inventoryManager.ResourceAmount += tower.TowerScriptableObject.GetCost();
+        inventoryManager.ResourceAmount += tower.TowerScriptableObject.Cost;
 
         RemoveInteractable(tower);
         Destroy(tower.gameObject);
@@ -351,5 +363,4 @@ public partial class PlayerStateController : MonoBehaviour
         obj.transform.parent = null;
         SetState(PlayerStates.FREE);
     }
-
 }

--- a/Assets/Scripts/Player/PlayerStateController.cs
+++ b/Assets/Scripts/Player/PlayerStateController.cs
@@ -128,7 +128,12 @@ public partial class PlayerStateController : MonoBehaviour
                 UpdateConstructionTowerTargetCell();
                 if (Cancel)
                 {
-                    SellTower();
+                    //Refund turret
+                    inventoryManager.ResourceAmount += ui.GetSelectedSegment().cost;
+
+                    RemoveInteractable(heldInteractable);
+                    Destroy(heldInteractable.gameObject);
+                    heldInteractable = null;
                     SetState(PlayerStates.FREE);
                 }
 
@@ -199,7 +204,11 @@ public partial class PlayerStateController : MonoBehaviour
                 if (heldInteractable)
                 {
                     //Refund turret
-                    SellTower();
+                    inventoryManager.ResourceAmount += ui.GetSelectedSegment().cost;
+
+                    RemoveInteractable(heldInteractable);
+                    Destroy(heldInteractable.gameObject);
+                    heldInteractable = null;
                 }
 
                 SetFocusedInteractable(null);
@@ -328,17 +337,6 @@ public partial class PlayerStateController : MonoBehaviour
         if (interactable)
             interactable.Focus(this);
         focusedInteractable = interactable;
-    }
-
-    private void SellTower()
-    {
-        if (!(heldInteractable is TurretPrefabConstruction tower))
-            return;
-
-        inventoryManager.ResourceAmount += tower.TowerScriptableObject.getCost();
-
-        RemoveInteractable(tower);
-        Destroy(tower.gameObject);
     }
 
     public void Lift(GameObject obj)

--- a/Assets/Scripts/Player/PlayerStateController.cs
+++ b/Assets/Scripts/Player/PlayerStateController.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+
+
 public enum PlayerStates
 {
     IN_ANIMATION,
@@ -11,66 +13,92 @@ public enum PlayerStates
     BUILDING,
     IN_TURRET_MENU,
 }
+
 /// <summary>
 /// The input-related code is in <c>PlayerStateController_Input.cs</c>.
 /// </summary>
 public partial class PlayerStateController : MonoBehaviour
 {
     private HealthLogic health; // Reference to the health script
+
     [TextLabel(greyedOut = true), SerializeField]
     private PlayerStates _currentState = PlayerStates.FREE;
+
     private PlayerSpecificManager manager;
     private PlayerMotion motion;
     private PlayerUi ui;
     private InventoryManager inventoryManager;
+
     private HashSet<Interactable> interactables = new HashSet<Interactable>(); // List of interactables in range
+    
     [ReadOnly, SerializeField]
     private Interactable heldInteractable;
+    
     [ReadOnly, SerializeField]
     private Interactable focusedInteractable; // The currently focused interactable
+    
     [ReadOnly, SerializeField]
     private GameObject liftedObject; // Object being lifted
+    
     public Transform inventory; // Where items are carried
+    
     private HexGrid terrain; // Reference to the terrain
+    
     [ReadOnly, SerializeField]
     private HexCell targetCell;
+    
     [SerializeField]
     private Animator anim; //Reference to animation controller of the player
+    
     [SerializeField]
     private Transform heldItemBone;
+    
     public PlayerStates CurrentState { get => _currentState; private set => _currentState = value; }
+    
     public delegate void PlayerStateDelegate(PlayerStates newState, PlayerStates oldState);
+    
     public PlayerStateDelegate onPlayerStateChange; //To allow other components to subscribe to stateChange events
+    
     private static readonly int liftingAnimatorParam = Animator.StringToHash("Lifting");
     private static readonly int planningAnimatorParam = Animator.StringToHash("Planning");
+   
     void Awake()
     {
         motion = GetComponent<PlayerMotion>();
         health = GetComponent<HealthLogic>();
         health.onDeath += Die;
+
         ui = GetComponent<PlayerUi>();
         terrain = GameObject.FindGameObjectWithTag("Grid").GetComponent<HexGrid>();
     }
+
     void OnDestroy()
     {
         health.onDeath -= Die;
+
         OnDestroy_Input();
     }
+    
     private void Die(DamageInfo dmg)
     {
         // Drop anything we are carrying
         if (liftedObject)
             liftedObject.GetComponent<Interactable>().Interact(this);
+
         SetState(PlayerStates.DEAD);
         manager.RespawnPlayer(1f);
+
         CameraFocusController.Singleton.RemoveFocusObject(transform);
         Destroy(gameObject);
     }
+
     void Start()
     {
         inventoryManager = InventoryManager.Singleton;
+
         CurrentState = PlayerStates.FREE;
     }
+
     void FixedUpdate()
     {
         switch (CurrentState)
@@ -86,6 +114,7 @@ public partial class PlayerStateController : MonoBehaviour
             case PlayerStates.FREE:
                 UpdateFocusedInteractable();
                 motion.Move();
+
                 if (Select)
                     SetState(PlayerStates.IN_TURRET_MENU);
                 break;
@@ -105,31 +134,37 @@ public partial class PlayerStateController : MonoBehaviour
 
                 if (Interact)
                     SetState(PlayerStates.FREE);
+
                 break;
             default:
                 break;
         }
     }
+
     private void UpdateConstructionTowerTargetCell()
     {
         targetCell = terrain.GetCell(transform.position + HexMetrics.OUTER_RADIUS * 2f * transform.forward);
         focusedInteractable.GetComponent<TurretPrefabConstruction>().FocusCell(targetCell);
     }
+
     void OnTriggerEnter(Collider other)
     {
         Interactable interactable = other.GetComponentInParent<Interactable>();
         if (interactable && interactable.canInteract)
             AddInteractable(interactable);
     }
+
     void OnTriggerExit(Collider other)
     {
         if (other.GetComponentInParent<Interactable>())
             RemoveInteractable(other.GetComponentInParent<Interactable>());
     }
+
     public void SetState(PlayerStates state)
     {
         if (state == CurrentState)
             return;
+
         onPlayerStateChange?.Invoke(state, CurrentState); //In case any script wants to subscribe to state change events
         //Cleanup from previous state
         switch (CurrentState)
@@ -153,6 +188,7 @@ public partial class PlayerStateController : MonoBehaviour
             default:
                 break;
         }
+
         //Effects when changing to state
         switch (state)
         {
@@ -183,19 +219,24 @@ public partial class PlayerStateController : MonoBehaviour
             default:
                 break;
         }
+
         CurrentState = state;
     }
+
     // Gets called when interact button is pressed
     private void OnInteract()
     {
         if (!focusedInteractable)
             return;
+
         if (!focusedInteractable.canInteract)
         {
             RemoveInteractable(focusedInteractable);
             return;
         }
+
         focusedInteractable.Interact(this); // interact with the current target
+
         if (CurrentState == PlayerStates.BUILDING && !targetCell.IsOccupied)
         {
             // Build the turret we are holding
@@ -205,24 +246,30 @@ public partial class PlayerStateController : MonoBehaviour
             SetState(PlayerStates.FREE);
         }
     }
+
     // Called when the "Move tower" button is pressed
     private void OnMoveTower()
     {
         if (!(focusedInteractable is TowerLogic tower))
             return;
+
         tower.TowerScriptableObject.InstantiateConstructionTower(this);
         SetState(PlayerStates.BUILDING);
+
         RemoveInteractable(tower);
         Destroy(tower.gameObject);
     }
+
     public void AddInteractable(Interactable interactable)
     {
         interactables.Add(interactable);
     }
+
     public void RemoveInteractable(Interactable interactable)
     {
         interactables.Remove(interactable);
     }
+
     // Update the focused interactable based on distance from player
     private void UpdateFocusedInteractable()
     {
@@ -232,6 +279,7 @@ public partial class PlayerStateController : MonoBehaviour
             SetFocusedInteractable(heldInteractable);
             return;
         }
+
         if (interactables.Count == 0)
         {
             if (focusedInteractable) // The object we were focusing is no longer focusable
@@ -239,16 +287,16 @@ public partial class PlayerStateController : MonoBehaviour
                 focusedInteractable.Unfocus(this);
                 focusedInteractable = null;
             }
+
             // Otherwise do nothing
             return;
-        }
-        else if (interactables.Count == 1) // If there is only one interactable object select that object
+        } else if (interactables.Count == 1) // If there is only one interactable object select that object
         {
             SetFocusedInteractable(interactables.Single());
             return;
-        }
-        else if (!focusedInteractable && !heldInteractable) // Wait until we have at least one object to interact with
+        } else if (!focusedInteractable && !heldInteractable) // Wait until we have at least one object to interact with
             return;
+
         // Otherwise get closest interactable
         Interactable closest = focusedInteractable;
         float closestDistSqr = (focusedInteractable.transform.position - transform.position).sqrMagnitude;
@@ -263,8 +311,10 @@ public partial class PlayerStateController : MonoBehaviour
                 closest = interactable;
             }
         }
+
         SetFocusedInteractable(closest);
     }
+
     private void SetFocusedInteractable(Interactable interactable)
     {
         if (focusedInteractable == interactable)
@@ -272,6 +322,7 @@ public partial class PlayerStateController : MonoBehaviour
             // This is already the focused interactable
             return;
         }
+
         if (focusedInteractable)
             focusedInteractable.Unfocus(this);
         if (interactable)
@@ -297,6 +348,7 @@ public partial class PlayerStateController : MonoBehaviour
         obj.transform.SetParent(heldItemBone);
         obj.transform.localPosition = Vector3.zero;
     }
+
     public void PrepareTurret(Interactable turret)
     {
         AddInteractable(turret);
@@ -304,10 +356,12 @@ public partial class PlayerStateController : MonoBehaviour
         SetFocusedInteractable(turret);
         UpdateConstructionTowerTargetCell();
     }
+
     public void Drop(GameObject obj)
     {
         liftedObject = null;
         obj.transform.parent = null;
         SetState(PlayerStates.FREE);
     }
+
 }

--- a/Assets/Scripts/Player/PlayerStateController.cs
+++ b/Assets/Scripts/Player/PlayerStateController.cs
@@ -128,12 +128,7 @@ public partial class PlayerStateController : MonoBehaviour
                 UpdateConstructionTowerTargetCell();
                 if (Cancel)
                 {
-                    //Refund turret
-                    inventoryManager.ResourceAmount += ui.GetSelectedSegment().cost;
-
-                    RemoveInteractable(heldInteractable);
-                    Destroy(heldInteractable.gameObject);
-                    heldInteractable = null;
+                    SellTower();
                     SetState(PlayerStates.FREE);
                 }
 
@@ -204,11 +199,7 @@ public partial class PlayerStateController : MonoBehaviour
                 if (heldInteractable)
                 {
                     //Refund turret
-                    inventoryManager.ResourceAmount += ui.GetSelectedSegment().cost;
-
-                    RemoveInteractable(heldInteractable);
-                    Destroy(heldInteractable.gameObject);
-                    heldInteractable = null;
+                    SellTower();
                 }
 
                 SetFocusedInteractable(null);
@@ -337,6 +328,17 @@ public partial class PlayerStateController : MonoBehaviour
         if (interactable)
             interactable.Focus(this);
         focusedInteractable = interactable;
+    }
+
+    private void SellTower()
+    {
+        if (!(heldInteractable is TurretPrefabConstruction tower))
+            return;
+
+        inventoryManager.ResourceAmount += tower.TowerScriptableObject.getCost();
+
+        RemoveInteractable(tower);
+        Destroy(tower.gameObject);
     }
 
     public void Lift(GameObject obj)

--- a/Assets/Scripts/Player/PlayerStateController.cs
+++ b/Assets/Scripts/Player/PlayerStateController.cs
@@ -30,35 +30,23 @@ public partial class PlayerStateController : MonoBehaviour
     private InventoryManager inventoryManager;
 
     private HashSet<Interactable> interactables = new HashSet<Interactable>(); // List of interactables in range
-    
     [ReadOnly, SerializeField]
     private Interactable heldInteractable;
-    
     [ReadOnly, SerializeField]
     private Interactable focusedInteractable; // The currently focused interactable
-    
     [ReadOnly, SerializeField]
     private GameObject liftedObject; // Object being lifted
-    
     public Transform inventory; // Where items are carried
-    
     private HexGrid terrain; // Reference to the terrain
-    
     [ReadOnly, SerializeField]
     private HexCell targetCell;
-    
     [SerializeField]
     private Animator anim; //Reference to animation controller of the player
-    
     [SerializeField]
     private Transform heldItemBone;
-    
     public PlayerStates CurrentState { get => _currentState; private set => _currentState = value; }
-    
     public delegate void PlayerStateDelegate(PlayerStates newState, PlayerStates oldState);
-    
     public PlayerStateDelegate onPlayerStateChange; //To allow other components to subscribe to stateChange events
-    
     private static readonly int liftingAnimatorParam = Animator.StringToHash("Lifting");
     private static readonly int planningAnimatorParam = Animator.StringToHash("Planning");
    
@@ -335,7 +323,7 @@ public partial class PlayerStateController : MonoBehaviour
         if (!(heldInteractable is TurretPrefabConstruction tower))
             return;
 
-        inventoryManager.ResourceAmount += tower.TowerScriptableObject.getCost();
+        inventoryManager.ResourceAmount += tower.TowerScriptableObject.GetCost();
 
         RemoveInteractable(tower);
         Destroy(tower.gameObject);

--- a/Assets/Scripts/Player/PlayerUi.cs
+++ b/Assets/Scripts/Player/PlayerUi.cs
@@ -52,9 +52,9 @@ public class PlayerUi : MonoBehaviour
         {
             TowerScriptableObject selectedSegment = GetSelectedSegment();
             if (selectedSegment
-                && inventory.ResourceAmount - selectedSegment.GetCost() >= 0)
+                && inventory.ResourceAmount - selectedSegment.Cost >= 0)
             {
-                inventory.ResourceAmount -= selectedSegment.GetCost();
+                inventory.ResourceAmount -= selectedSegment.Cost;
                 selectedSegment.InstantiateConstructionTower(state);
                 state.SetState(PlayerStates.BUILDING);
             } else

--- a/Assets/Scripts/Player/PlayerUi.cs
+++ b/Assets/Scripts/Player/PlayerUi.cs
@@ -52,9 +52,9 @@ public class PlayerUi : MonoBehaviour
         {
             TowerScriptableObject selectedSegment = GetSelectedSegment();
             if (selectedSegment
-                && inventory.ResourceAmount - selectedSegment.cost >= 0)
+                && inventory.ResourceAmount - selectedSegment.GetCost() >= 0)
             {
-                inventory.ResourceAmount -= selectedSegment.cost;
+                inventory.ResourceAmount -= selectedSegment.GetCost();
                 selectedSegment.InstantiateConstructionTower(state);
                 state.SetState(PlayerStates.BUILDING);
             } else

--- a/Assets/Scripts/ScriptableObjects/TowerScriptableObject.cs
+++ b/Assets/Scripts/ScriptableObjects/TowerScriptableObject.cs
@@ -8,21 +8,20 @@ using UnityEngine.UI;
 public class TowerScriptableObject : ScriptableObject
 {
     public string towerName;
+
     [SerializeField]
     private int cost;
+
     public TurretPrefabConstruction towerConstructionPrefab;
     public Sprite icon;
     public Sprite iconHighlight;
+
+    public int Cost => cost;
 
     public TurretPrefabConstruction InstantiateConstructionTower(PlayerStateController controller)
     {
         GameObject spawnedConstructionTower = Instantiate(towerConstructionPrefab.gameObject);
         controller.PrepareTurret(spawnedConstructionTower.GetComponent<Interactable>());
         return spawnedConstructionTower.GetComponent<TurretPrefabConstruction>();
-    }
-
-    public int GetCost()
-    {
-        return cost;
     }
 }

--- a/Assets/Scripts/ScriptableObjects/TowerScriptableObject.cs
+++ b/Assets/Scripts/ScriptableObjects/TowerScriptableObject.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
-
-
 [CreateAssetMenu(menuName = "TowerScriptableObject")]
 public class TowerScriptableObject : ScriptableObject
 {
@@ -12,11 +10,15 @@ public class TowerScriptableObject : ScriptableObject
     public TurretPrefabConstruction towerConstructionPrefab;
     public Sprite icon;
     public Sprite iconHighlight;
-
     public TurretPrefabConstruction InstantiateConstructionTower(PlayerStateController controller)
     {
         GameObject spawnedConstructionTower = Instantiate(towerConstructionPrefab.gameObject);
         controller.PrepareTurret(spawnedConstructionTower.GetComponent<Interactable>());
         return spawnedConstructionTower.GetComponent<TurretPrefabConstruction>();
+    }
+
+    public int getCost()
+    {
+        return cost;
     }
 }

--- a/Assets/Scripts/ScriptableObjects/TowerScriptableObject.cs
+++ b/Assets/Scripts/ScriptableObjects/TowerScriptableObject.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+
+
 [CreateAssetMenu(menuName = "TowerScriptableObject")]
 public class TowerScriptableObject : ScriptableObject
 {
@@ -10,6 +12,7 @@ public class TowerScriptableObject : ScriptableObject
     public TurretPrefabConstruction towerConstructionPrefab;
     public Sprite icon;
     public Sprite iconHighlight;
+
     public TurretPrefabConstruction InstantiateConstructionTower(PlayerStateController controller)
     {
         GameObject spawnedConstructionTower = Instantiate(towerConstructionPrefab.gameObject);

--- a/Assets/Scripts/ScriptableObjects/TowerScriptableObject.cs
+++ b/Assets/Scripts/ScriptableObjects/TowerScriptableObject.cs
@@ -19,4 +19,9 @@ public class TowerScriptableObject : ScriptableObject
         controller.PrepareTurret(spawnedConstructionTower.GetComponent<Interactable>());
         return spawnedConstructionTower.GetComponent<TurretPrefabConstruction>();
     }
+
+    public int getCost()
+    {
+        return cost;
+    }
 }

--- a/Assets/Scripts/ScriptableObjects/TowerScriptableObject.cs
+++ b/Assets/Scripts/ScriptableObjects/TowerScriptableObject.cs
@@ -19,9 +19,4 @@ public class TowerScriptableObject : ScriptableObject
         controller.PrepareTurret(spawnedConstructionTower.GetComponent<Interactable>());
         return spawnedConstructionTower.GetComponent<TurretPrefabConstruction>();
     }
-
-    public int getCost()
-    {
-        return cost;
-    }
 }

--- a/Assets/Scripts/ScriptableObjects/TowerScriptableObject.cs
+++ b/Assets/Scripts/ScriptableObjects/TowerScriptableObject.cs
@@ -8,7 +8,8 @@ using UnityEngine.UI;
 public class TowerScriptableObject : ScriptableObject
 {
     public string towerName;
-    public int cost;
+    [SerializeField]
+    private int cost;
     public TurretPrefabConstruction towerConstructionPrefab;
     public Sprite icon;
     public Sprite iconHighlight;
@@ -20,7 +21,7 @@ public class TowerScriptableObject : ScriptableObject
         return spawnedConstructionTower.GetComponent<TurretPrefabConstruction>();
     }
 
-    public int getCost()
+    public int GetCost()
     {
         return cost;
     }

--- a/Assets/Scripts/Towers/TurretPrefabConstruction.cs
+++ b/Assets/Scripts/Towers/TurretPrefabConstruction.cs
@@ -1,11 +1,14 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-
-
 public class TurretPrefabConstruction : Interactable
 {
     public GameObject tower;
+
+    [SerializeField]
+    private TowerScriptableObject _towerScriptableObject;
+
+    public TowerScriptableObject TowerScriptableObject => _towerScriptableObject;
 
     public void Construct(HexCell targetCell)
     {
@@ -13,10 +16,8 @@ public class TurretPrefabConstruction : Interactable
         targetCell.OccupyingObject = t;
         Destroy(gameObject);
     }
-
     public override void Interact(PlayerStateController player)
-    {}
-
+    { }
     public void FocusCell(HexCell targetCell)
     {
         transform.position = targetCell.transform.position;

--- a/Assets/Scripts/Towers/TurretPrefabConstruction.cs
+++ b/Assets/Scripts/Towers/TurretPrefabConstruction.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+
+
 public class TurretPrefabConstruction : Interactable
 {
     public GameObject tower;
@@ -16,8 +18,10 @@ public class TurretPrefabConstruction : Interactable
         targetCell.OccupyingObject = t;
         Destroy(gameObject);
     }
+
     public override void Interact(PlayerStateController player)
-    { }
+    {}
+
     public void FocusCell(HexCell targetCell)
     {
         transform.position = targetCell.transform.position;

--- a/Assets/Scripts/Towers/TurretPrefabConstruction.cs
+++ b/Assets/Scripts/Towers/TurretPrefabConstruction.cs
@@ -7,11 +7,6 @@ public class TurretPrefabConstruction : Interactable
 {
     public GameObject tower;
 
-    [SerializeField]
-    private TowerScriptableObject _towerScriptableObject;
-
-    public TowerScriptableObject TowerScriptableObject => _towerScriptableObject;
-
     public void Construct(HexCell targetCell)
     {
         GameObject t = Instantiate(tower, targetCell.transform.position, tower.transform.rotation, targetCell.transform);

--- a/Assets/Scripts/Towers/TurretPrefabConstruction.cs
+++ b/Assets/Scripts/Towers/TurretPrefabConstruction.cs
@@ -7,6 +7,11 @@ public class TurretPrefabConstruction : Interactable
 {
     public GameObject tower;
 
+    [SerializeField]
+    private TowerScriptableObject _towerScriptableObject;
+
+    public TowerScriptableObject TowerScriptableObject => _towerScriptableObject;
+
     public void Construct(HexCell targetCell)
     {
         GameObject t = Instantiate(tower, targetCell.transform.position, tower.transform.rotation, targetCell.transform);


### PR DESCRIPTION
Fixed a bug where selling a tower after dying would give errors.

accidentally managed to push to develop, so here is the original commit message:

> Made refunding turrets it's own function, and updated the towerScriptableObject with get function. While testing for this bugfix, I found that playerstatecontroller doesn't actually set or update liftedObject, which made the scriptableobject unaccessable. Until this is resolved, the sellTower function in playerstatecontroller will use the holo prefab for cost variable access.