### PR TITLE
Axe shot parenting fix

### DIFF
--- a/Assets/Scripts/Towers/Specific towers/Axe turret/AxeProjectile.cs
+++ b/Assets/Scripts/Towers/Specific towers/Axe turret/AxeProjectile.cs
@@ -9,7 +9,7 @@ public class AxeProjectile : MonoBehaviour
 
     void Start()
     {
-        Destroy(gameObject, 10f);
+        Destroy(gameObject, 1f);
     }
 
     void OnTriggerEnter(Collider other)

--- a/Assets/Scripts/Towers/Specific towers/Axe turret/AxeTowerAnimationController.cs
+++ b/Assets/Scripts/Towers/Specific towers/Axe turret/AxeTowerAnimationController.cs
@@ -21,7 +21,7 @@ public class AxeTowerAnimationController : MonoBehaviour, TurretInterface
     public void Shoot()
     {
         handAxe.enabled = false;
-        Rigidbody projectileBody = Instantiate(axeProjectilePrefab, spawnPoint.position, spawnPoint.rotation)
+        Rigidbody projectileBody = Instantiate(axeProjectilePrefab, spawnPoint.position, spawnPoint.rotation, gameObject.transform)
             .GetComponent<Rigidbody>();
         projectileBody.velocity = forwardTransform.right * projectileSpeed;
     }

--- a/Assets/Scripts/Towers/Specific towers/Axe turret/AxeTowerAnimationController.cs
+++ b/Assets/Scripts/Towers/Specific towers/Axe turret/AxeTowerAnimationController.cs
@@ -21,7 +21,7 @@ public class AxeTowerAnimationController : MonoBehaviour, TurretInterface
     public void Shoot()
     {
         handAxe.enabled = false;
-        Rigidbody projectileBody = Instantiate(axeProjectilePrefab, spawnPoint.position, spawnPoint.rotation, gameObject.transform)
+        Rigidbody projectileBody = Instantiate(axeProjectilePrefab, spawnPoint.position, spawnPoint.rotation, transform)
             .GetComponent<Rigidbody>();
         projectileBody.velocity = forwardTransform.right * projectileSpeed;
     }


### PR DESCRIPTION
Made axe tower instantiate axe shots as children to keep scene more tidy. Reduced lifetime of axe projectiles for gamebalance, as discussed on relevant Trello card.