### PR TITLE
Add non-occupying scenery

### DIFF
--- a/Assets/Prefabs/Terrain/HexGrid.prefab
+++ b/Assets/Prefabs/Terrain/HexGrid.prefab
@@ -49,10 +49,12 @@ MonoBehaviour:
   cellPrefab: {fileID: 3232745420878418644, guid: 344428ef3825a48459c49cc3f55d5f2b, type: 3}
   cells: []
   edgeCells: []
-  sceneryObjects:
+  occupyingSceneryObjects:
   - {fileID: 582512043729321896, guid: d516299b5c2ef0c41bef1c06bf150d76, type: 3}
   - {fileID: 6453742252294820681, guid: 3f8b52c6be1c3af44b7be0ed2b1e604a, type: 3}
   - {fileID: 8390892766367341337, guid: 98175291f4e95704baf1a9612e215751, type: 3}
+  nonOccupyingSceneryObjects:
+  - {fileID: 4525528604836273348, guid: c98672e40ed3e434c8a5259d8b2cf0a7, type: 3}
   mountainBorder: 1
   treeBorder: 1
   noise: {fileID: 2800000, guid: 600eed7c653e4b34db0e0ba17c323e1a, type: 3}

--- a/Assets/Prefabs/Terrain/Scenery/Grass model.prefab
+++ b/Assets/Prefabs/Terrain/Scenery/Grass model.prefab
@@ -26,7 +26,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 632085302824876712}
   m_LocalRotation: {x: -0.66435486, y: 0.20306404, z: 0.15056194, w: 0.70336956}
-  m_LocalPosition: {x: -1.0050251, y: -0.012506227, z: -0.005538357}
+  m_LocalPosition: {x: 0, y: -0.05, z: 0}
   m_LocalScale: {x: 1.4289627, y: 1.4289626, z: 1.4289627}
   m_Children: []
   m_Father: {fileID: 1231975208940651491}
@@ -91,7 +91,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1231975208940651491}
   m_Layer: 0
-  m_Name: Gass model
+  m_Name: Grass model
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -105,7 +105,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4525528604836273348}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 57.099663, y: 1.6190808, z: 30.316105}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 256228641337204754}

--- a/Assets/Prefabs/Terrain/Scenery/Grass sprite.prefab
+++ b/Assets/Prefabs/Terrain/Scenery/Grass sprite.prefab
@@ -27,7 +27,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3680291520346813509}
   m_LocalRotation: {x: 0, y: -0.7071068, z: 0.7071068, w: 0}
-  m_LocalPosition: {x: 5.844, y: 0.8, z: 4.297}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 0.1353297, y: 1, z: 0.13268831}
   m_Children: []
   m_Father: {fileID: 2625758019104648830}
@@ -106,7 +106,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2625758019104648830}
   m_Layer: 0
-  m_Name: Gass sprite
+  m_Name: Grass sprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -120,7 +120,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6452384112250327819}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 51.25566, y: 0.8190808, z: 26.019106}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8166181917108228900}

--- a/Assets/Prefabs/Terrain/Scenery/Rocks 2 (the sequel).prefab
+++ b/Assets/Prefabs/Terrain/Scenery/Rocks 2 (the sequel).prefab
@@ -24,7 +24,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3391637675697672429}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 57.099663, y: 1.6190808, z: 30.316105}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8762822506094287583}
@@ -57,7 +57,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8273143339574624357}
   m_LocalRotation: {x: -0.0061704423, y: 0.7070799, z: 0.7070798, w: 0.0061704423}
-  m_LocalPosition: {x: -2.0386992, y: 0.004583921, z: 0.10680176}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 10.115609, y: 10.115609, z: 2.0462039}
   m_Children: []
   m_Father: {fileID: 6857156834994225390}

--- a/Assets/Prefabs/Terrain/Scenery/Rocks.prefab
+++ b/Assets/Prefabs/Terrain/Scenery/Rocks.prefab
@@ -27,7 +27,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1209725201876186303}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.011705, y: 0.16532, z: 0.26386}
+  m_LocalPosition: {x: 0.011705, y: 0.389, z: 0.26386}
   m_LocalScale: {x: 0.44628, y: 0.80719995, z: 0.58344}
   m_Children: []
   m_Father: {fileID: 6227868901235789675}
@@ -155,7 +155,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6557089505114002392}
   m_LocalRotation: {x: 0, y: -0.3420201, z: 0, w: 0.9396927}
-  m_LocalPosition: {x: -0.65174, y: -0.10308, z: 0.011517}
+  m_LocalPosition: {x: -0.65174, y: 0.12060001, z: 0.011517}
   m_LocalScale: {x: 0.29446897, y: 0.26333964, z: 0.307152}
   m_Children: []
   m_Father: {fileID: 6227868901235789675}
@@ -250,7 +250,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6811043478663159002}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.25269, y: -0.15151, z: -0.3123}
+  m_LocalPosition: {x: 0.25269, y: 0.072170004, z: -0.3123}
   m_LocalScale: {x: 0.29446897, y: 0.26333964, z: 0.30715203}
   m_Children: []
   m_Father: {fileID: 6227868901235789675}

--- a/Assets/Prefabs/Terrain/Scenery/Ruins.prefab
+++ b/Assets/Prefabs/Terrain/Scenery/Ruins.prefab
@@ -26,8 +26,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2939033975143149116}
   m_LocalRotation: {x: 0.7389599, y: -0.36224946, z: 0.41332203, w: 0.3897159}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 21.369053, y: 21.192026, z: 17.232134}
+  m_LocalPosition: {x: 0, y: 0.2, z: 0}
+  m_LocalScale: {x: 14.251663, y: 14.133598, z: 11.492627}
   m_Children: []
   m_Father: {fileID: 1796837387318764745}
   m_RootOrder: 0
@@ -107,7 +107,7 @@ Transform:
   m_GameObject: {fileID: 5055192187505742122}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.433476, y: 1.433476, z: 1.433476}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2558708112433771654}
   m_Father: {fileID: 0}

--- a/Assets/Prefabs/Terrain/Scenery/flower.prefab
+++ b/Assets/Prefabs/Terrain/Scenery/flower.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4008354742035258314}
   m_Layer: 0
-  m_Name: flower 1
+  m_Name: flower
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -24,7 +24,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 451174524977401633}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 51.095497, y: -1.0000005, z: 25.5}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8682076323565439057}

--- a/Assets/Prefabs/Terrain/Scenery/stonePile01.prefab
+++ b/Assets/Prefabs/Terrain/Scenery/stonePile01.prefab
@@ -26,7 +26,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4781727031773735436}
   m_LocalRotation: {x: 0.00000008146034, y: 0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0.08, z: 0}
   m_LocalScale: {x: 2.570373, y: 2.570373, z: 2.570373}
   m_Children: []
   m_Father: {fileID: 9167534640297673123}
@@ -107,7 +107,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7598791529300457275}
   m_LocalRotation: {x: 0.00000008146034, y: 0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalPosition: {x: -0, y: 0.08, z: 0}
   m_LocalScale: {x: 2.570373, y: 2.570373, z: 2.570373}
   m_Children: []
   m_Father: {fileID: 9167534640297673123}
@@ -188,7 +188,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8305664576366408270}
   m_LocalRotation: {x: 0.00000008146034, y: 0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0.08, z: 0}
   m_LocalScale: {x: 2.570373, y: 2.570373, z: 2.570373}
   m_Children: []
   m_Father: {fileID: 9167534640297673123}
@@ -267,7 +267,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8390892766367341337}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5.37, y: 0.5, z: 7.49}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 6.1463265, y: 6.1463265, z: 6.1463265}
   m_Children:
   - {fileID: 5187283415240838651}

--- a/Assets/Prefabs/Terrain/Scenery/tree01.prefab
+++ b/Assets/Prefabs/Terrain/Scenery/tree01.prefab
@@ -26,7 +26,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5921078085937623894}
   m_LocalRotation: {x: 0.000000081460335, y: 0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.002222648, y: 0.038667206, z: -0.010797152}
+  m_LocalPosition: {x: 0, y: 0.12, z: 0}
   m_LocalScale: {x: 4.2606754, y: 4.2606754, z: 4.2606754}
   m_Children: []
   m_Father: {fileID: 5970538139742505459}
@@ -105,7 +105,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6453742252294820681}
   m_LocalRotation: {x: -0, y: 0.788995, z: -0, w: 0.61439955}
-  m_LocalPosition: {x: 4.693955, y: 0.39999998, z: 5.7643194}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 7.351841, y: 7.351841, z: 7.351841}
   m_Children:
   - {fileID: 3183593188261846108}
@@ -139,7 +139,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7587605090617460644}
   m_LocalRotation: {x: 0.000000081460335, y: 0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.002222648, y: 0.038667206, z: -0.010797152}
+  m_LocalPosition: {x: 0, y: 0.12, z: 0}
   m_LocalScale: {x: 4.2606754, y: 4.2606754, z: 4.2606754}
   m_Children: []
   m_Father: {fileID: 5970538139742505459}

--- a/Assets/Prefabs/Terrain/Scenery/tree02.prefab
+++ b/Assets/Prefabs/Terrain/Scenery/tree02.prefab
@@ -24,7 +24,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 582512043729321896}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4.8096, y: 0.66, z: 8.89}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 8.908649, y: 8.908649, z: 8.908649}
   m_Children:
   - {fileID: 3634641503325918148}
@@ -58,7 +58,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1126528842906538444}
   m_LocalRotation: {x: 0.00000008146034, y: 0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.0011563943, y: 0.01337837, z: -0.000533565}
+  m_LocalPosition: {x: 0, y: 0.09, z: 0}
   m_LocalScale: {x: 3.4490943, y: 3.4490943, z: 3.4490943}
   m_Children: []
   m_Father: {fileID: 242824061513573650}
@@ -139,7 +139,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8959107651552536838}
   m_LocalRotation: {x: 0.00000008146034, y: 0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.0011563943, y: 0.01337837, z: -0.000533565}
+  m_LocalPosition: {x: 0, y: 0.09, z: 0}
   m_LocalScale: {x: 3.4490943, y: 3.4490943, z: 3.4490943}
   m_Children: []
   m_Father: {fileID: 242824061513573650}

--- a/Assets/Scripts/Terrain/HexCell.cs
+++ b/Assets/Scripts/Terrain/HexCell.cs
@@ -110,6 +110,19 @@ public class HexCell : MonoBehaviour
         meshRenderer = GetComponentInChildren<MeshRenderer>();
     }
 
+    public GameObject InstantiatePrefabOnCell(GameObject prefab)
+    {
+        if (IsOccupied)
+        {
+            Debug.LogError($"Cannot place {prefab} on cell at {coordinates}, as it's already occupied by {OccupyingObject}!");
+            return null;
+        }
+
+        GameObject obj = Instantiate(prefab, transform.position, Quaternion.identity, transform);
+        OccupyingObject = obj;
+        return obj;
+    }
+
     public HexCell GetNeighbor(HexDirection direction)
     {
         return neighbors[(int)direction];

--- a/Assets/Scripts/Terrain/HexGrid.cs
+++ b/Assets/Scripts/Terrain/HexGrid.cs
@@ -36,7 +36,10 @@ public class HexGrid : MonoBehaviour
 
     [Header("Scenery Variables")]
     [SerializeField]
-    private GameObject[] sceneryObjects;
+    private GameObject[] occupyingSceneryObjects;
+
+    [SerializeField]
+    private GameObject[] nonOccupyingSceneryObjects;
 
     [SerializeField]
     private bool mountainBorder;
@@ -97,7 +100,7 @@ public class HexGrid : MonoBehaviour
         nameToGameObject = new Dictionary<string, GameObject>();
         gameObjectToName = new Dictionary<GameObject, string>();
 
-        IEnumerable<GameObject> allGameObjectArrays = towerPrefabs.Concat(sceneryObjects);
+        IEnumerable<GameObject> allGameObjectArrays = towerPrefabs.Concat(occupyingSceneryObjects).Concat(nonOccupyingSceneryObjects);
         foreach (GameObject obj in allGameObjectArrays)
         {
             string gameObjectName = $"{obj.name}(Clone)";
@@ -286,7 +289,7 @@ public class HexGrid : MonoBehaviour
     /// </summary>
     private void PlaceSceneryObjects()
     {
-        if (sceneryObjects.Length == 0)
+        if (occupyingSceneryObjects.Length == 0)
         {
             Debug.LogError("No scenery objects have been assigned!");
             return;
@@ -295,7 +298,8 @@ public class HexGrid : MonoBehaviour
         // Code from https://stackoverflow.com/a/3188804
         HexCellType tallestCellType = cellTypes.Aggregate((t1, t2) => t1.elevation > t2.elevation ? t1 : t2);
         PlaceSceneryOnMapEdge(tallestCellType);
-        PlaceSceneryOnPlayArea(tallestCellType);
+        PlaceSceneryOnPlayArea(occupyingSceneryObjects, true, tallestCellType);
+        PlaceSceneryOnPlayArea(nonOccupyingSceneryObjects, false, tallestCellType);
     }
 
     private void PlaceSceneryOnMapEdge(HexCellType tallestCellType)
@@ -308,14 +312,14 @@ public class HexGrid : MonoBehaviour
 
             if (treeBorder)
             {
-                GameObject sceneryObj = cell.InstantiatePrefabOnCell(sceneryObjects[0]);
+                GameObject sceneryObj = cell.InstantiatePrefabOnCell(occupyingSceneryObjects[0]);
                 float yRotation = Random.Range(0f, 360f);
                 sceneryObj.transform.Rotate(0, yRotation, 0);
             }
         }
     }
 
-    private void PlaceSceneryOnPlayArea(HexCellType tallestCellType)
+    private void PlaceSceneryOnPlayArea(GameObject[] sceneryObjects, bool occupying, HexCellType tallestCellType)
     {
         foreach (HexCell cell in cells)
         {
@@ -330,6 +334,9 @@ public class HexGrid : MonoBehaviour
             GameObject sceneryObject = cell.InstantiatePrefabOnCell(sceneryObjects[sceneryIndex]);
             float yRotation = Random.Range(0f, 360f);
             sceneryObject.transform.Rotate(0, yRotation, 0);
+
+            if (!occupying)
+                cell.OccupyingObject = null;
         }
     }
 

--- a/Assets/Scripts/Terrain/HexGrid.cs
+++ b/Assets/Scripts/Terrain/HexGrid.cs
@@ -303,11 +303,9 @@ public class HexGrid : MonoBehaviour
 
             if (treeBorder)
             {
-                GameObject sceneryObj = Instantiate(sceneryObjects[0], cell.transform.position, Quaternion.identity);
-                sceneryObj.transform.SetParent(cell.transform);
+                GameObject sceneryObj = cell.InstantiatePrefabOnCell(sceneryObjects[0]);
                 float yRotation = Random.Range(0f, 360f);
                 sceneryObj.transform.Rotate(0, yRotation, 0);
-                cell.OccupyingObject = sceneryObj;
             }
         }
 
@@ -321,11 +319,9 @@ public class HexGrid : MonoBehaviour
                 continue;
 
             int sceneryIndex = Random.Range(0, sceneryObjects.Length);
-            GameObject sceneryObject = Instantiate(sceneryObjects[sceneryIndex], cell.transform.position, Quaternion.identity);
+            GameObject sceneryObject = cell.InstantiatePrefabOnCell(sceneryObjects[sceneryIndex]);
             float yRotation = Random.Range(0f, 360f);
             sceneryObject.transform.Rotate(0, yRotation, 0);
-            sceneryObject.transform.SetParent(cell.transform);
-            cell.OccupyingObject = sceneryObject;
         }
     }
 
@@ -358,7 +354,7 @@ public class HexGrid : MonoBehaviour
             if (hexCellData.occupier == "null" || !nameToGameObject.ContainsKey(hexCellData.occupier))
                 continue;
 
-            GameObject sceneryObject = Instantiate(nameToGameObject[hexCellData.occupier], cells[i].transform.position, Quaternion.identity);
+            GameObject sceneryObject = cells[i].InstantiatePrefabOnCell(nameToGameObject[hexCellData.occupier]);
             if (sceneryObject.GetComponent<RotatableTowerLogic>() is RotatableTowerLogic rotatableTowerLogic)
             {
                 Quaternion rotation = rotatableTowerLogic.rotAxis.rotation;
@@ -367,9 +363,6 @@ public class HexGrid : MonoBehaviour
             {
                 sceneryObject.transform.rotation = Quaternion.Euler(0f, hexCellData.occupierRotation, 0f);
             }
-
-            sceneryObject.transform.SetParent(cells[i].transform);
-            cells[i].OccupyingObject = sceneryObject;
         }
     }
 }

--- a/Assets/Scripts/Terrain/HexGrid.cs
+++ b/Assets/Scripts/Terrain/HexGrid.cs
@@ -121,7 +121,7 @@ public class HexGrid : MonoBehaviour
 
         PlacePlayerBase();
 
-        CreateSceneryObjects();
+        PlaceSceneryObjects();
     }
 
     private void PlacePlayerBase()
@@ -284,7 +284,7 @@ public class HexGrid : MonoBehaviour
     /// <summary>
     /// Creates the map decorations
     /// </summary>
-    private void CreateSceneryObjects()
+    private void PlaceSceneryObjects()
     {
         if (sceneryObjects.Length == 0)
         {
@@ -294,7 +294,12 @@ public class HexGrid : MonoBehaviour
 
         // Code from https://stackoverflow.com/a/3188804
         HexCellType tallestCellType = cellTypes.Aggregate((t1, t2) => t1.elevation > t2.elevation ? t1 : t2);
+        PlaceSceneryOnMapEdge(tallestCellType);
+        PlaceSceneryOnPlayArea(tallestCellType);
+    }
 
+    private void PlaceSceneryOnMapEdge(HexCellType tallestCellType)
+    {
         // Adding a wall around the map
         foreach (HexCell cell in edgeCells)
         {
@@ -308,7 +313,10 @@ public class HexGrid : MonoBehaviour
                 sceneryObj.transform.Rotate(0, yRotation, 0);
             }
         }
+    }
 
+    private void PlaceSceneryOnPlayArea(HexCellType tallestCellType)
+    {
         foreach (HexCell cell in cells)
         {
             float elevation = cell.CellType.elevation;


### PR DESCRIPTION
*Depends on #90; this PR should change base to `develop` automatically after #90 has been merged.*

Main summary:
* Enabled generating non-occupying scenery objects (3a2428fd400166adc0247601cb5bf9b28ec428f1)
  * It would be quite frustrating if the map were littered with cells you're unable to build towers on, just because some grass is placed on them. This adds an extra `GameObject` list to `HexGrid` - `nonOccupyingSceneryObjects` - which places scenery objects without occupying the hex cells they're placed on.
  * `HexGrid` now generates the map with grass placed randomly
* Moved scenery prefab objects to ground level (bbb1af291502d3c4682e39f284bd1f9c46679fa0)
  * Now the rocks are no longer placed below ground ✨

See each commit message for additional changes and details.